### PR TITLE
Feat: support type 3 transactions on tx stream

### DIFF
--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,9 +1,27 @@
 import { TransactionFactory } from "@ethereumjs/tx";
+import { Chain, Common, Hardfork } from "@ethereumjs/common";
+import { initKZG } from "@ethereumjs/util";
+import { createKZG } from "kzg-wasm";
+/**
+ * KZG setup, along with [`Common`] transaction options are needed
+ * to support EIP-4844 type-3 transactions.
+ *
+ * References:
+ *   - https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx#kzg-setup
+ *   - https://github.com/ethereumjs/ethereumjs-monorepo/blob/7c500b70b5f593a8811fc214a3b86085188da755/packages/tx/examples/blobTx.ts
+ */
+const kzg = await createKZG();
+initKZG(kzg, "");
+const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Cancun,
+    customCrypto: { kzg },
+});
 /**
  *
  * @param raw a raw transaction in RLP format
  * @returns an Ethereumjs TypedTransaction object
  */
 export function fromRLPTransaction(raw) {
-    return TransactionFactory.fromSerializedData(raw);
+    return TransactionFactory.fromSerializedData(raw, { common });
 }

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -23,8 +23,7 @@ async function switchToCancun() {
     if (currentHardfork === Hardfork.Cancun)
         return;
     const now = new Date().getTime();
-    const cancunTimestampMs = 1710338135000;
-    const timeToCancun = cancunTimestampMs - now;
+    const timeToCancun = CANCUN_TIMESTAMP_MS - now;
     await new Promise((resolve) => setTimeout(resolve, timeToCancun));
     common = new Common({
         chain: Chain.Mainnet,

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -12,11 +12,27 @@ import { createKZG } from "kzg-wasm";
  */
 const kzg = await createKZG();
 initKZG(kzg, "");
-const common = new Common({
+const CANCUN_TIMESTAMP_MS = 1710338135000;
+const currentHardfork = new Date().getTime() < CANCUN_TIMESTAMP_MS ? Hardfork.Shanghai : Hardfork.Cancun;
+let common = new Common({
     chain: Chain.Mainnet,
-    hardfork: Hardfork.Cancun,
+    hardfork: currentHardfork,
     customCrypto: { kzg },
 });
+async function switchToCancun() {
+    if (currentHardfork === Hardfork.Cancun)
+        return;
+    const now = new Date().getTime();
+    const cancunTimestampMs = 1710338135000;
+    const timeToCancun = cancunTimestampMs - now;
+    await new Promise((resolve) => setTimeout(resolve, timeToCancun));
+    common = new Common({
+        chain: Chain.Mainnet,
+        hardfork: Hardfork.Cancun,
+        customCrypto: { kzg },
+    });
+}
+switchToCancun();
 /**
  *
  * @param raw a raw transaction in RLP format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiber-ts",
-  "version": "1.9.1",
+  "version": "1.10.2",
   "description": "Client package for connecting to Fiber Network",
   "repository": {
     "url": "https://github.com/chainbound/fiber-ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiber-ts",
-  "version": "1.10.1",
+  "version": "1.9.1",
   "description": "Client package for connecting to Fiber Network",
   "repository": {
     "url": "https://github.com/chainbound/fiber-ts"
@@ -27,14 +27,15 @@
   },
   "dependencies": {
     "@ethereumjs/block": "^5.1.1",
-    "@ethereumjs/common": "^4.0.0",
+    "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/tx": "^5.2.1",
-    "@ethereumjs/util": "^9.0.0",
+    "@ethereumjs/util": "^9.0.2",
     "@grpc/grpc-js": "^1.6.12",
     "@lodestar/types": "^1.15.1",
     "ethers": "^5.7.0",
-    "google-protobuf": "^3.21.0"
+    "google-protobuf": "^3.21.0",
+    "kzg-wasm": "^0.2.0"
   },
   "scripts": {
     "build": "rm -rf dist && tsc --build",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,8 +28,7 @@ async function switchToCancun() {
   if (currentHardfork === Hardfork.Cancun) return;
 
   const now = new Date().getTime();
-  const cancunTimestampMs = 1710338135000;
-  const timeToCancun = cancunTimestampMs - now;
+  const timeToCancun = CANCUN_TIMESTAMP_MS - now;
 
   await new Promise<void>((resolve) => setTimeout(resolve, timeToCancun));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,24 @@
 import { TransactionFactory, TypedTransaction } from "@ethereumjs/tx";
+import { Chain, Common, Hardfork } from "@ethereumjs/common";
+import { initKZG } from "@ethereumjs/util";
+import { createKZG } from "kzg-wasm";
+
+/**
+ * KZG setup, along with [`Common`] transaction options are needed
+ * to support EIP-4844 type-3 transactions.
+ *
+ * References:
+ *   - https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx#kzg-setup
+ *   - https://github.com/ethereumjs/ethereumjs-monorepo/blob/7c500b70b5f593a8811fc214a3b86085188da755/packages/tx/examples/blobTx.ts
+ */
+const kzg = await createKZG();
+initKZG(kzg, "");
+
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg },
+});
 
 /**
  *
@@ -6,5 +26,5 @@ import { TransactionFactory, TypedTransaction } from "@ethereumjs/tx";
  * @returns an Ethereumjs TypedTransaction object
  */
 export function fromRLPTransaction(raw: string | Uint8Array): TypedTransaction {
-  return TransactionFactory.fromSerializedData(raw as Uint8Array);
+  return TransactionFactory.fromSerializedData(raw as Uint8Array, { common });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,11 +14,33 @@ import { createKZG } from "kzg-wasm";
 const kzg = await createKZG();
 initKZG(kzg, "");
 
-const common = new Common({
+const CANCUN_TIMESTAMP_MS = 1710338135000;
+const currentHardfork =
+  new Date().getTime() < CANCUN_TIMESTAMP_MS ? Hardfork.Shanghai : Hardfork.Cancun;
+
+let common = new Common({
   chain: Chain.Mainnet,
-  hardfork: Hardfork.Cancun,
+  hardfork: currentHardfork,
   customCrypto: { kzg },
 });
+
+async function switchToCancun() {
+  if (currentHardfork === Hardfork.Cancun) return;
+
+  const now = new Date().getTime();
+  const cancunTimestampMs = 1710338135000;
+  const timeToCancun = cancunTimestampMs - now;
+
+  await new Promise<void>((resolve) => setTimeout(resolve, timeToCancun));
+
+  common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Cancun,
+    customCrypto: { kzg },
+  });
+}
+
+switchToCancun();
 
 /**
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,14 +42,6 @@
     "@ethereumjs/util" "^9.0.2"
     ethereum-cryptography "^2.1.3"
 
-"@ethereumjs/common@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-4.0.0.tgz#da99cdc822041da02753867d4773683f91e5854f"
-  integrity sha512-eVa0/nC15mpotD8HOq6jB883SCWUkLjibr2jLPmPrx4FfmewXqFeh4drgR2sHjq3qWKxpCLK+5qsSJgtXwIzJQ==
-  dependencies:
-    "@ethereumjs/util" "^9.0.0"
-    crc "^4.3.2"
-
 "@ethereumjs/common@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-4.2.0.tgz#c5ccaeb71f5a9833c66ab35c22f9f965ce462ace"
@@ -57,7 +49,7 @@
   dependencies:
     "@ethereumjs/util" "^9.0.2"
 
-"@ethereumjs/rlp@^5.0.0", "@ethereumjs/rlp@^5.0.2":
+"@ethereumjs/rlp@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-5.0.2.tgz#c89bd82f2f3bec248ab2d517ae25f5bbc4aac842"
   integrity sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==
@@ -84,14 +76,6 @@
     "@ethereumjs/rlp" "^5.0.2"
     "@ethereumjs/util" "^9.0.2"
     ethereum-cryptography "^2.1.3"
-
-"@ethereumjs/util@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-9.0.0.tgz#ac5945c629f3ab2ac584d8b12a8513e8eac29dc4"
-  integrity sha512-V8062I+ZXfFxtFLp7xsPeiT1IxDaVOZaM78nGj1gsWUFeZ8SgADMLDKWehp+muTy1JRbVoXFljZ1qoyv9ji/2g==
-  dependencies:
-    "@ethereumjs/rlp" "^5.0.0"
-    ethereum-cryptography "^2.1.2"
 
 "@ethereumjs/util@^9.0.2":
   version "9.0.2"
@@ -770,11 +754,6 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-crc@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-4.3.2.tgz#49b7821cbf2cf61dfd079ed93863bbebd5469b9a"
-  integrity sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -830,7 +809,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-ethereum-cryptography@^2.1.2, ethereum-cryptography@^2.1.3:
+ethereum-cryptography@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz#1352270ed3b339fe25af5ceeadcf1b9c8e30768a"
   integrity sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==
@@ -1009,6 +988,11 @@ js-sha3@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
+kzg-wasm@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/kzg-wasm/-/kzg-wasm-0.2.0.tgz#04f26f8e8dc4b6b357052102ad7064d40087e21c"
+  integrity sha512-Gv54Edtv7GnzZ253t1ooEtPuD+pCa5SavNmyQ7MQPdlMpLZZHXzX8vIvNIWlMHfPy+TvPX8ubRUzy1AoPxl5jA==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
This PR enables listening to type 3 transaction on tx stream, according to `@ethereumjs/tx` [docs](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx#kzg-setup).

Testing has been done against both Fiber beta api endpoint and with the new type 3 transactions generated with our tests.